### PR TITLE
Scroll lock as next song key

### DIFF
--- a/KeyboardRemap/ahk_keyboard_remap_all.exe.ahk
+++ b/KeyboardRemap/ahk_keyboard_remap_all.exe.ahk
@@ -1,9 +1,12 @@
 #Include ../std/ENV.ahk
 #Include BaseRemap.ahk
 
-$F1::Send {Volume_Mute}
-$F2::Send {Volume_Down}
-$F3::Send {Volume_Up}
-$#F1::Send {F1} ; Required for vscode
-$#F2::Send {F2} ; Required for vscode
-$#F3::Send {F3} ; Required for vscode
+$F1:: Send { Volume_Mute }
+$F2:: Send { Volume_Down }
+$F3:: Send { Volume_Up }
+$#F1:: Send { F1 } ; Required for vscode
+$#F2:: Send { F2 } ; Required for vscode
+$#F3:: Send { F3 } ; Required for vscode
+
+$ScrollLock:: Send { Media_Next }
+$#ScrollLock:: Send { ScrollLock }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Maps `ScrollLock` to `Media_Next` and preserves original `ScrollLock` via Win+`ScrollLock` in `KeyboardRemap/ahk_keyboard_remap_all.exe.ahk`.
> 
> - **Keyboard remap** (`KeyboardRemap/ahk_keyboard_remap_all.exe.ahk`):
>   - Map `ScrollLock` to `Media_Next`.
>   - Add passthrough: Win+`ScrollLock` sends `ScrollLock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44ad17c007da3bb3c396e1ae94d713446a4362ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->