### PR TITLE
More media Keys and Window management

### DIFF
--- a/KeyboardRemap/ahk_keyboard_remap_all.exe.ahk
+++ b/KeyboardRemap/ahk_keyboard_remap_all.exe.ahk
@@ -9,4 +9,14 @@ $#F2:: Send { F2 } ; Required for vscode
 $#F3:: Send { F3 } ; Required for vscode
 
 $ScrollLock:: Send { Media_Next }
+$Pause:: Send { Media_Play_Pause }
 $#ScrollLock:: Send { ScrollLock }
+
+#Pause::
+WinGet, windowState, MinMax, A
+if (windowState = 1) { ; Window is maximized
+    WinRestore, A
+} else { ; Window is not maximized (restored or minimized)
+    WinMaximize, A
+}
+return

--- a/KeyboardRemap/ahk_keyboard_remap_all.exe.ahk
+++ b/KeyboardRemap/ahk_keyboard_remap_all.exe.ahk
@@ -12,13 +12,62 @@ $ScrollLock:: Send { Media_Next }
 Pause:: Send { Media_Play_Pause }
 $#ScrollLock:: Send { ScrollLock }
 
-F11::
-WinGet, windowState, MinMax, A
-if (windowState = 1) { ; Window is maximized
-    WinRestore, A
-} else { ; Window is not maximized (restored or minimized)
-    WinMaximize, A
+; --- Window Maximize/Restore Helper Function ---
+ToggleMaximizeRestore() {
+    local windowState
+    WinGet, windowState, MinMax, A
+    if (windowState = 1)
+        WinRestore, A
+    else
+        WinMaximize, A
 }
+
+; F11 and various Win+Arrow combos toggle maximize/restore
+F11::
+#Down::
+#Up::
+#^Down::
+#^Up::
+#+Down::
+#+Up::
+    ToggleMaximizeRestore()
 return
 
 $#F11:: Send { F11 }
+
+; Win+Alt+Up: Maximize if not maximized, else restore
+#!Up::
+    WinGet, windowState, MinMax, A
+    if (windowState != 1)
+        Send, #{Up}
+    else
+        ToggleMaximizeRestore()
+return
+
+; Win+Alt+Down: Restore if maximized, else maximize
+#!Down::
+    WinGet, windowState, MinMax, A
+    if (windowState = 1)
+        Send, #{Down}
+    else
+        ToggleMaximizeRestore()
+return
+
+; Default - Win+Alt+Left/Right moves windows in thirds
+; Win+Left/Right => Win+Alt+Left/Right, move in thirds instead of in halfs/quarters
+#Left:: Send, #!{Left}
+#Right:: Send, #!{Right}
+; Default - Win+Arrows moves windows in halfs/quarters
+; Win+Alt+Left/Right => Win+Left/Right, move in halfs/quarters instead of in thirds
+#!Left:: Send, #{Left}
+#!Right:: Send, #{Right}
+
+; Default - Win+Shift+Left/Right Moves the window across monitors
+; Ctrl+Win+Left/Right => Shift+Win+Left/Right
+#^Left:: Send, #+{Left}
+#^Right:: Send, #+{Right}
+
+; F12 to cycle windows through monitors
+$F12:: Send, #+{Right}
+$+F12:: Send, #+{Left}
+$#F12:: Send {F12}

--- a/KeyboardRemap/ahk_keyboard_remap_all.exe.ahk
+++ b/KeyboardRemap/ahk_keyboard_remap_all.exe.ahk
@@ -20,3 +20,5 @@ if (windowState = 1) { ; Window is maximized
     WinMaximize, A
 }
 return
+
+$#F11:: Send { F11 }

--- a/KeyboardRemap/ahk_keyboard_remap_all.exe.ahk
+++ b/KeyboardRemap/ahk_keyboard_remap_all.exe.ahk
@@ -9,10 +9,10 @@ $#F2:: Send { F2 } ; Required for vscode
 $#F3:: Send { F3 } ; Required for vscode
 
 $ScrollLock:: Send { Media_Next }
-$Pause:: Send { Media_Play_Pause }
+$#Pause:: Send { Media_Play_Pause }
 $#ScrollLock:: Send { ScrollLock }
 
-#Pause::
+Pause::
 WinGet, windowState, MinMax, A
 if (windowState = 1) { ; Window is maximized
     WinRestore, A

--- a/KeyboardRemap/ahk_keyboard_remap_all.exe.ahk
+++ b/KeyboardRemap/ahk_keyboard_remap_all.exe.ahk
@@ -9,10 +9,10 @@ $#F2:: Send { F2 } ; Required for vscode
 $#F3:: Send { F3 } ; Required for vscode
 
 $ScrollLock:: Send { Media_Next }
-$#Pause:: Send { Media_Play_Pause }
+Pause:: Send { Media_Play_Pause }
 $#ScrollLock:: Send { ScrollLock }
 
-Pause::
+F11::
 WinGet, windowState, MinMax, A
 if (windowState = 1) { ; Window is maximized
     WinRestore, A

--- a/TTS/TTS.ahk
+++ b/TTS/TTS.ahk
@@ -29,9 +29,8 @@ return
 ;   -q              : add application to queue
 TextCleanup(string){
 	quote = "
-	StringReplace, string, string, %quote%	, , All
-	StringReplace, string, string, '		, , All
-	StringReplace, string, string, `,		, , All ;escape comma
+	; Use a single regex to remove unwanted characters and URL patterns
+	string := RegExReplace(string, "i)(https?://|www\.|[""'`,!@#$%^&*_?/\\])", "")
 	return string
 }
 Read(transcript,voice,speed=0,pitch=0,volume=100,pause_sentence=0,pause_paragraphs=0){


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `$#Pause` for media play/pause and makes `Pause` toggle the active window between maximized and restored.
> 
> - **AHK Remaps**:
>   - **Media Controls**: Map `$#Pause` to `Media_Play_Pause`.
>   - **Window Management**: Bind `Pause` to toggle the active window between maximized and restored.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33334f308d0b24fa6eb5d042160159839ee005e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->