### PR TITLE
WIn+Alt+Arrow and Win+Arrow didn't work well

### DIFF
--- a/KeyboardRemap/MoveWindowHotkeys.ahk
+++ b/KeyboardRemap/MoveWindowHotkeys.ahk
@@ -41,12 +41,13 @@ return
 
 ; Default - Win+Alt+Left/Right moves windows in thirds
 ; Win+Left/Right => Win+Alt+Left/Right, move in thirds instead of in halfs/quarters
-#Left:: Send, #!{Left}
-#Right:: Send, #!{Right}
+$#Left:: Send, {Blind}!{Left}
+$#Right:: Send, {Blind}!{Right}
 ; Default - Win+Arrows moves windows in halfs/quarters
 ; Win+Alt+Left/Right => Win+Left/Right, move in halfs/quarters instead of in thirds
-#!Left:: Send, #{Left}
-#!Right:: Send, #{Right}
+; Very slow?
+; $#!Left:: Send, #{Left}
+; $#!Right:: Send, #{Right}
 
 ; Default - Win+Shift+Left/Right Moves the window across monitors
 ; Ctrl+Win+Left/Right => Shift+Win+Left/Right


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves reliability of window-moving remaps.
> 
> - Changes `#Left/#Right` handlers to `$#Left/$#Right` and sends `{Blind}!{Left/Right}` so the Win modifier is preserved, ensuring thirds-based movement works
> - Leaves the reverse mappings (`#!Left/Right` -> `#{Left/Right}`) commented out due to performance concerns
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b9ac39f46aff06f8c5508dcc74300256be54c65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->