### PR TITLE
feat: Focus-under-mouse improvements, modifier reset, and Edge tab mouse-follow

### DIFF
--- a/KeyboardRemap/BaseRemap.ahk
+++ b/KeyboardRemap/BaseRemap.ahk
@@ -142,7 +142,6 @@ $~*^n::
 $~^+w::
 $~!n::
 $~+!n::
-$~^+a::
     sleep 150
     MoveMouseToSelectedWindow()
 return
@@ -154,6 +153,21 @@ return
 $~*#Right Up::
     MoveMouseToSelectedWindow()
 return
+
+; In Edge: if Enter is pressed and the window under the mouse changes, refocus to that window
+#IfWinActive ahk_exe msedge.exe
+    $*Enter::
+        Critical On
+        WinGet, edgeActiveBefore, ID, A
+        Send {Blind}{Enter}
+        WinWaitNotActive, ahk_id %edgeActiveBefore%,, 0.75
+        WinGet, edgeActiveAfter, ID, A
+        tooltip, % "edgeActiveBefore: " edgeActiveBefore " edgeActiveAfter: " edgeActiveAfter
+        if (edgeActiveBefore != edgeActiveAfter) {
+            MoveMouseToSelectedWindow()
+        }
+    return
+#If  ; end Edge Enter directive
 
 $~*!Tab::
     global tabPressed, beforeAltTabClass

--- a/KeyboardRemap/BaseRemap.ahk
+++ b/KeyboardRemap/BaseRemap.ahk
@@ -142,7 +142,7 @@ $~*^n::
 $~^+w::
 $~!n::
 $~+!n::
-    sleep 350
+    sleep 750
     MoveMouseToSelectedWindow()
 return
 
@@ -162,7 +162,7 @@ return
         Send {Blind}{Enter}
         WinWaitNotActive, ahk_id %edgeActiveBefore%,, 0.75
         WinGet, edgeActiveAfter, ID, A
-        tooltip, % "edgeActiveBefore: " edgeActiveBefore " edgeActiveAfter: " edgeActiveAfter
+        ; tooltip, % "edgeActiveBefore: " edgeActiveBefore " edgeActiveAfter: " edgeActiveAfter
         if (edgeActiveBefore != edgeActiveAfter) {
             MoveMouseToSelectedWindow()
         }

--- a/KeyboardRemap/BaseRemap.ahk
+++ b/KeyboardRemap/BaseRemap.ahk
@@ -142,6 +142,7 @@ $~*^n::
 $~^+w::
 $~!n::
 $~+!n::
+$~^+a::
     sleep 150
     MoveMouseToSelectedWindow()
 return

--- a/KeyboardRemap/BaseRemap.ahk
+++ b/KeyboardRemap/BaseRemap.ahk
@@ -163,7 +163,7 @@ ShowWindowInfo(windowId, windowLabel := "") {
 #F7::
     MouseGetPos, , , MouseWinID
     ShowWindowInfo(MouseWinID, "Window under mouse")
-    SetTimer, RemoveMouseTooltip, -25000  ; Remove after 2.5s
+    SetTimer, RemoveMouseTooltip, -25000  ; Remove after 25s
 Return
 
 RemoveMouseTooltip:
@@ -173,7 +173,7 @@ Return
 #F8::
     WinGet, activeWinID, ID, A
     ShowWindowInfo(activeWinID, "Active window")
-    SetTimer, RemoveActiveTooltip, -25000  ; Remove after 2.5s
+    SetTimer, RemoveActiveTooltip, -25000  ; Remove after 25s
 Return
 
 RemoveActiveTooltip:

--- a/KeyboardRemap/BaseRemap.ahk
+++ b/KeyboardRemap/BaseRemap.ahk
@@ -28,6 +28,19 @@ global ModifierTriggerCounts := {}
 #Include KeyboardLayout.ahk
 #Persistent
 
+; https://www.autohotkey.com/boards/viewtopic.php?t=118246 - Detecting When Any New Window Is Created or Displayed?
+; DllCall("RegisterShellHookWindow", "UInt", A_ScriptHwnd)
+; OnMessage(DllCall("RegisterWindowMessage", "Str", "SHELLHOOK"), "winCenter")
+
+; winCenter(wParam, lParam) {
+;  If (wParam != WINDOWCREATED := 1)
+;   Return
+;  WinGet
+;  WinGet pname, ProcessName, % winTitle := "ahk_id" lParam
+;  Tooltip, % "Window created: " pname " lParam: " lParam " wParam: " wParam
+;  Return
+; }
+
 loadLaptopKeyboardState() {
     global laptopKeyboardStateFile
     if (FileExist(laptopKeyboardStateFile)) {
@@ -124,6 +137,16 @@ MoveMouseToSelectedWindow(){
     }
 }
 
+; New Window Hotkeys make the mouse follow the window
+$~*^n::
+$~^+w::
+$~!n::
+$~+!n::
+    sleep 150
+    MoveMouseToSelectedWindow()
+return
+
+; Moving Windows makes the mouse follow the window
 $~*#Left Up::
     MoveMouseToSelectedWindow()
 return

--- a/KeyboardRemap/BaseRemap.ahk
+++ b/KeyboardRemap/BaseRemap.ahk
@@ -142,7 +142,7 @@ $~*^n::
 $~^+w::
 $~!n::
 $~+!n::
-    sleep 150
+    sleep 350
     MoveMouseToSelectedWindow()
 return
 


### PR DESCRIPTION
## Summary

Improves the "focus window under mouse" behavior when holding Ctrl, adds a modifier stuck-key fix, and makes the mouse follow the active window in more cases (including Microsoft Edge tab switches).

## Changes

### Focus-under-mouse behavior
- Renamed `focusUnderMouseHandler` → `focusUnderMouseThenHotkeyHandler` (focus window first, then send hotkey)
- Added `HotkeyThenFocusUnderMouseHandler` (send hotkey first, then focus window under mouse) for `$*c::`
- All focus-under-mouse hotkeys now call `CheckAndResetModifier()` to avoid stuck modifiers

### Modifier stuck-key fix
- Added `CheckAndResetModifier()` to detect when a modifier’s logical state differs from its physical state
- After 5 triggers, if a modifier is logically pressed but not physically pressed, sends a key-up to reset it
- Supports LControl, RControl, LShift, RShift, LAlt, RAlt, LWin, RWin

### Mouse follows window
- **New window hotkeys** (`Ctrl+N`, `Ctrl+Shift+W`, `Alt+N`, `Shift+Alt+N`): move mouse to the newly created/selected window after 750ms
- **Win+Left/Right**: already moved mouse on key up; no change
- **Microsoft Edge tab switching**:
  - Clicking a tab (`Chrome_WidgetWin_2`) or pressing Enter in the tab bar moves the mouse to the newly focused Edge window
  - `Ctrl+Shift+A` records the current Edge window ID for context
  - `msedgeWinID` tracks the active Edge window across these actions

### Internal changes
- Replaced `mousePressedClass` with `mousePressedID`; window class is derived from ID when needed
- Added globals: `ModifierTriggerCounts`, `msedgeWinID`

### Debug tools
- `ShowWindowInfo(windowId, label)` – shows window details in a tooltip
- `Win+F7` – window under mouse
- `Win+F8` – active window
- Tooltips auto-remove after 25s

## Testing

- [ ] Ctrl+focus: focus window under mouse, then send key
- [ ] Ctrl+C: send key, then focus window under mouse
- [ ] Stuck modifier: hold Ctrl, trigger focus-under-mouse 5+ times, release Ctrl; modifier should reset
- [ ] Edge: click tab or press Enter in tab bar; mouse should move to new window
- [ ] New window: Ctrl+N / Alt+N; mouse should move to new window after ~750ms