### PR TITLE
fix: Correct tooltip syntax and add new hotkeys for window management

### DIFF
--- a/KeyboardRemap/BaseRemap.ahk
+++ b/KeyboardRemap/BaseRemap.ahk
@@ -332,7 +332,7 @@ CheckAndResetModifier(mod := "") {
             if (logicalPressed != physicalPressed) {
                 if (logicalPressed) {
                     Send, {%key% up}
-                    tooltip, % "Sending {%key% up} logicalPressed: " logicalPressed " physicalPressed: " physicalPressed
+                    ToolTip, % "Sending {" key " up} logicalPressed: " logicalPressed " physicalPressed: " physicalPressed
                 }
             }
         }

--- a/KeyboardRemap/MoveWindowHotkeys.ahk
+++ b/KeyboardRemap/MoveWindowHotkeys.ahk
@@ -58,3 +58,47 @@ $#Right:: Send, {Blind}!{Right}
 $F12:: Send, #+{Right}
 $+F12:: Send, #+{Left}
 $#F12:: Send {F12}
+
+
+$#F10::
+    Send, #z
+    WinWaitActive, ahk_class XamlExplorerHostlslandWindow,, 0.75
+    WinGet, newPopupID, ID, A
+    WinGetTitle, newPopupTitle, ahk_id %newPopupID%
+    if (newPopupTitle = "") {
+        Send 42
+    } else {
+        ; Retry the hotkey once if not successful
+        Send, #z
+        WinWaitActive, ahk_class XamlExplorerHostlslandWindow,, 0.75
+        WinGet, retryPopupID, ID, A
+        WinGetTitle, retryPopupTitle, ahk_id %retryPopupID%
+        if (retryPopupTitle = "") {
+            Send 42
+        } else {
+            ToolTip, % "Not PopupHost - retried"
+        }
+    }
+return
+
+
+$#F9::
+    Send, #z
+    WinWaitActive, ahk_class XamlExplorerHostlslandWindow,, 0.75
+    WinGet, newPopupID, ID, A
+    WinGetTitle, newPopupTitle, ahk_id %newPopupID%
+    if (newPopupTitle = "") {
+        Send 41
+    } else {
+        ; Retry the hotkey once if not successful
+        Send, #z
+        WinWaitActive, ahk_class XamlExplorerHostlslandWindow,, 0.75
+        WinGet, retryPopupID, ID, A
+        WinGetTitle, retryPopupTitle, ahk_id %retryPopupID%
+        if (retryPopupTitle = "") {
+            Send 41
+        } else {
+            ToolTip, % "Not PopupHost - retried"
+        }
+    }
+return


### PR DESCRIPTION
- Updated tooltip syntax in CheckAndResetModifier function for consistency.
- Introduced new hotkeys ($#F10 and $#F9) for enhanced window management, including retry logic for window activation and feedback via tooltips.
- Improved user interaction by ensuring proper handling of new window creation and focus behavior.