### PR TITLE
- Reduced the static threshold for modifier key resets from 5 to 3 for improved responsiveness.

### DIFF
--- a/KeyboardRemap/BaseRemap.ahk
+++ b/KeyboardRemap/BaseRemap.ahk
@@ -300,7 +300,7 @@ return
 
 CheckAndResetModifier(mod := "") {
     global ModifierTriggerCounts
-    static N := 5
+    static N := 3
     keyMap := { "LControl": "LControl", "RControl": "RControl"  , "LShift": "LShift", "RShift": "RShift"        , "LAlt": "LAlt", "RAlt": "RAlt"        , "LWin": "LWin", "RWin": "RWin"}
 
     keysToCheck := []
@@ -405,6 +405,8 @@ $~LCtrl::
     WinGetClass, classUnderMouse, ahk_id %id% ; Gets the title using the retrieved ID
     WinGetTitle, activeTitle, A
     WinGetClass, activeClass, A
+    WinGet, activeProc, ProcessName, A
+
     ; tooltip, % "titleUnderMouse: " titleUnderMouse " activeTitle: " activeTitle " classUnderMouse: " classUnderMouse " activeClass: " activeClass
     if (titleUnderMouse == "" && classUnderMouse == "") {
         ; tooltip, % "titleUnderMouse == "" && classUnderMouse == """
@@ -412,6 +414,9 @@ $~LCtrl::
     }
     if (titleUnderMouse == activeTitle && classUnderMouse == activeClass) { ; Same window under mouse, act normally
         ; tooltip, % "titleUnderMouse == activeTitle && classUnderMouse == activeClass"
+        return
+    }
+    if (activeProc == "msedge.exe" && activeTitle == "") {
         return
     }
     if (activeClass == "#32770"){ ; Win+R Run dialog


### PR DESCRIPTION
- Added process name retrieval for the active window to enhance handling of Microsoft Edge, preventing actions when the active title is empty.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core input-remapping behavior by triggering modifier key "unstick" logic more aggressively and adding an Edge-specific early return in the Ctrl focus-under-mouse hotkey, which could alter day-to-day keyboard/mouse interactions if mis-tuned.
> 
> **Overview**
> Improves responsiveness of the stuck-modifier recovery by lowering `CheckAndResetModifier`'s trigger threshold from 5 to 3, causing mismatched logical/physical modifier states to be corrected sooner.
> 
> Updates the `$~LCtrl` focus-under-mouse handler to read the active window process name and **skip focus switching when the active app is `msedge.exe` with an empty title**, avoiding unintended actions in Edge in that state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 702480e8a9e0f2e6700a8b09d830c0b13e1582ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->