### PR TITLE
fix: send Down arrow to Edge search popup after Ctrl+Shift+A

### DIFF
--- a/KeyboardRemap/BaseRemap.ahk
+++ b/KeyboardRemap/BaseRemap.ahk
@@ -244,7 +244,8 @@ return
         WinGetClass, newClass, ahk_id %newId%
         WinGet, newProc, ProcessName, ahk_id %newId%
         if (newProc = "msedge.exe" && newClass = "Chrome_WidgetWin_2") {
-            Sleep, 25
+            WinWaitActive, ahk_id %newId%,, 1
+            sleep 500
             SendInput, {Down}
         }
    


### PR DESCRIPTION
## Summary
- Replace unconditional `Sleep 25` (too short for Edge to register input) with `WinWaitActive` + `Sleep 500` before `SendInput {Down}`
- Ensures the `Chrome_WidgetWin_2` search popup window is fully active before the keystroke is sent

## Test plan
- [ ] Press `Ctrl+Shift+A` in Edge to open the Search Tabs popup
- [ ] Confirm the Down arrow key navigates the results in the popup